### PR TITLE
Refactor LM `predict` method to return a `DataFrame`

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -5,7 +5,7 @@ log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 
 # Change this to set Spark log level
-log4j.logger.org.apache.spark=INFO
+log4j.logger.org.apache.spark=WARN
 
 # Silence akka remoting
 log4j.logger.Remoting=WARN

--- a/src/main/scala/com/Alteryx/sparkGLM/LM.scala
+++ b/src/main/scala/com/Alteryx/sparkGLM/LM.scala
@@ -178,9 +178,9 @@ object LM {
   }
 
   // TODO: Create a summary method for prining model output.
-  def summary(obj: LM): LMSummary = {
-
-    
-  }
+  // def summary(obj: LM): LMSummary = {
+  //
+  //
+  // }
 
 }

--- a/src/test/scala/com/Alteryx/sparkGLM/lmPredict$Test.scala
+++ b/src/test/scala/com/Alteryx/sparkGLM/lmPredict$Test.scala
@@ -1,0 +1,36 @@
+package com.Alteryx.sparkGLM
+
+import org.apache.spark.sql.test.TestSQLContext
+import org.apache.spark.sql.functions._
+import org.scalatest.FunSuite
+import com.Alteryx.testUtils.data.testData._
+
+class lmPredict$Test extends FunSuite {
+  val sqlCtx = TestSQLContext
+
+  test("lmPredict with a single partition") {
+    val testDF = testDFSinglePart
+    val x = testDF.select("intercept", "x")
+    val y = testDF.select("y")
+    val lmTest = LM.fit(x, y)
+    val predicted = LM.predict(lmTest, x)
+
+    assert(predicted.getClass.getName == "org.apache.spark.sql.DataFrame")
+    assert(predicted.rdd.partitions.size == 1)
+    assert(predicted.columns.size == 2)
+    assert(predicted.agg(max("index")).collect.apply(0).get(0) == 49)
+  }
+
+  test("lmPredict with multiple partitions") {
+    val testDF = testDFMultiPart
+    val x = testDF.select("intercept", "x")
+    val y = testDF.select("y")
+    val lmTest = LM.fit(x, y)
+    val predicted = LM.predict(lmTest, x)
+
+    assert(predicted.getClass.getName == "org.apache.spark.sql.DataFrame")
+    assert(predicted.rdd.partitions.length == 4)
+    assert(predicted.columns.length == 2)
+    assert(predicted.agg(max("index")).collect.apply(0).get(0) == 49)
+  }
+}

--- a/src/test/scala/com/Alteryx/testUtils/data/testData.scala
+++ b/src/test/scala/com/Alteryx/testUtils/data/testData.scala
@@ -1,6 +1,7 @@
 package com.Alteryx.testUtils.data
 
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Row, DataFrame}
 import org.apache.spark.sql.test._
 import org.apache.spark.sql.test.TestSQLContext.implicits._
 
@@ -25,5 +26,71 @@ object testData {
       testRow(1, "a", 1.0) ::
       testRow(2, "b", 2.0) ::
       testRow(3, "a", 3.0) :: Nil).toDF()
+  }
+
+  val testRDD = TestSQLContext.sparkContext.parallelize(Seq(
+      Array(1.0, 1.1, 21.4),
+      Array(1.0, 2.2, 36.5),
+      Array(1.0, 3.3, 15.0),
+      Array(1.0, 4.4, 62.5),
+      Array(1.0, 5.5, 36.1),
+      Array(1.0, 6.6, 12.0),
+      Array(1.0, 7.7, 37.0),
+      Array(1.0, 8.8, 41.0),
+      Array(1.0, 9.9, 36.6),
+      Array(1.0, 11.0, 17.9),
+      Array(1.0, 12.1, 53.1),
+      Array(1.0, 13.2, 29.6),
+      Array(1.0, 14.3, 8.3),
+      Array(1.0, 15.4, -24.7),
+      Array(1.0, 16.5, 41.0),
+      Array(1.0, 17.6, 16.5),
+      Array(1.0, 18.7, 16.0),
+      Array(1.0, 19.8, 34.1),
+      Array(1.0, 20.9, 30.5),
+      Array(1.0, 22.0, 24.9),
+      Array(1.0, 23.1, 30.3),
+      Array(1.0, 24.2, 26.4),
+      Array(1.0, 25.3, 11.2),
+      Array(1.0, 26.4, -31.2),
+      Array(1.0, 27.5, 19.9),
+      Array(1.0, 28.6, 5.3),
+      Array(1.0, 29.7, 2.2),
+      Array(1.0, 30.8, -25.2),
+      Array(1.0, 31.9, -6.5),
+      Array(1.0, 33.0, 10.4),
+      Array(1.0, 34.1, 28.1),
+      Array(1.0, 35.2, -2.3),
+      Array(1.0, 36.3, 6.5),
+      Array(1.0, 37.4, -3.5),
+      Array(1.0, 38.5, -31.0),
+      Array(1.0, 39.6, -12.9),
+      Array(1.0, 40.7, -13.6),
+      Array(1.0, 41.8, -8.0),
+      Array(1.0, 42.9, 14.1),
+      Array(1.0, 44.0, 6.3),
+      Array(1.0, 45.1, -13.4),
+      Array(1.0, 46.2, -16.3),
+      Array(1.0, 47.3, 1.6),
+      Array(1.0, 48.4, -2.3),
+      Array(1.0, 49.5, -28.3),
+      Array(1.0, 50.6, -29.7),
+      Array(1.0, 51.7, -9.4),
+      Array(1.0, 52.8, -2.4),
+      Array(1.0, 53.9, -21.1),
+      Array(1.0, 55.0, -2.4)
+  ), 4).map(x => Row(x(0), x(1), x(2)))
+
+  val testSchema = StructType(
+      StructField("intercept", DoubleType, true) ::
+      StructField("x", DoubleType, true) ::
+      StructField("y", DoubleType, true) :: Nil)
+
+  val testDFSinglePart: DataFrame = {
+    TestSQLContext.createDataFrame(testRDD, testSchema).coalesce(1)
+  }
+
+  val testDFMultiPart: DataFrame = {
+    TestSQLContext.createDataFrame(testRDD, testSchema)
   }
 }


### PR DESCRIPTION
`predict` now returns a `DataFrame` with two columns: an `index` column (starting from 0), and a `value` column containing the predicted value.
